### PR TITLE
Code Saturne Modifications

### DIFF
--- a/software/apps/assets/code_saturne/4.0/code_saturne.cfg
+++ b/software/apps/assets/code_saturne/4.0/code_saturne.cfg
@@ -63,7 +63,7 @@ mpiexec = mpiexec
 ### type syntax, so quotes may be used here)
 # mpiexec_n = ' -n '
 ### Option to define number of ranks per node (e.g. ' -ppn 6 ', ' --ranks-per-node 16 ')
-# mpiexec_n_per_node =
+mpiexec_n_per_node = ''
 ### Separator after mpiexec options (':' for Blue Gene/Q without SLURM)
 # mpiexec_separator =
 ### Shell command to generate hostsfile if required. When using a fixed

--- a/software/apps/code_saturne_4.0.rst
+++ b/software/apps/code_saturne_4.0.rst
@@ -17,6 +17,26 @@ To make code saturne available, run the following module command after starting 
 
 :code:`module load apps/code_saturne/4.0.0`
 
+Troubleshooting
+---------------
+If you run Code Saturne jobs from ``/fastdata`` they will fail since the underlying filesystem used by ``/fastdata`` does not support posix locks. If you need more space than is available in your home directory, use ``/data`` instead. If you use ``/fastdata`` with Code Saturne you may get an error message similar to the one below ::
+
+  File locking failed in ADIOI_Set_lock(fd 14,cmd F_SETLKW/7,type F_WRLCK/1,whence 0) with return value FFFFFFFF and errno 26.
+  - If the file system is NFS, you need to use NFS version 3, ensure that the lockd daemon is running on all the machines, and mount the directory with the 'noac' option (no attribute caching).
+  - If the file system is LUSTRE, ensure that the directory is mounted with the 'flock' option.
+  ADIOI_Set_lock:: Function not implemented
+  ADIOI_Set_lock:offset 0, length 8
+  --------------------------------------------------------------------------
+  MPI_ABORT was invoked on rank 0 in communicator MPI_COMM_WORLD
+  with errorcode 1.
+  NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
+  You may or may not see output from other processes, depending on
+  exactly when Open MPI kills them.
+  --------------------------------------------------------------------------
+   solver script exited with status 1.
+  Error running the calculation.
+  Check Code_Saturne log (listing) and error* files for details.
+
 Installation Notes
 ------------------
 These notes are primarily for system administrators.
@@ -109,26 +129,26 @@ Module File Location: :code:`/usr/local/modulefiles/apps/code_saturne/4.0.0`
 
 .. code-block:: none
 
-	#%Module1.0#####################################################################
-	##
-	## code_saturne 4.0 module file
-	##
+  #%Module1.0#####################################################################
+  ##
+  ## code_saturne 4.0 module file
+  ##
 
-	## Module file logging
-	source /usr/local/etc/module_logging.tcl
-	##
+  ## Module file logging
+  source /usr/local/etc/module_logging.tcl
+  ##
 
-	proc ModulesHelp { } {
-		global code-saturneversion
+  proc ModulesHelp { } {
+  	global code-saturneversion
 
-		puts stderr "   Adds `code_saturn-$codesaturneversion' to your PATH environment variable and necessary libraries"
-	}
+  	puts stderr "   Adds `code_saturn-$codesaturneversion' to your PATH environment variable and necessary libraries"
+  }
 
-	set     codesaturneversion 4.0.
+  set     codesaturneversion 4.0.
   module load mpi/gcc/openmpi/1.8.3
 
-	module-whatis   "loads the necessary `code_saturne-$codesaturneversion' library paths"
+  module-whatis   "loads the necessary `code_saturne-$codesaturneversion' library paths"
 
-	set cspath /usr/local/packages6/apps/gcc/4.4.7/code_saturne/4.0
-	prepend-path MANPATH $cspath/share/man
-	prepend-path PATH $cspath/bin
+  set cspath /usr/local/packages6/apps/gcc/4.4.7/code_saturne/4.0
+  prepend-path MANPATH $cspath/share/man
+  prepend-path PATH $cspath/bin

--- a/software/apps/code_saturne_4.0.rst
+++ b/software/apps/code_saturne_4.0.rst
@@ -2,7 +2,7 @@ Code Saturne 4.0
 ================
 
 .. sidebar:: Code Saturne
-   
+
    :Version: 4.0
    :Support Level: Bronze
    :URL: http://code-saturne.org/cms/
@@ -33,7 +33,7 @@ This version of Code Saturne was built with the following:-
 * :ref:`HDF5` 1.8.14
 
 .. code-block:: none
-        
+
     module load libs/gcc/4.4.7/cgns/3.2.1
 
     tar -xvzf code_saturne-4.0.0.tar.gz
@@ -87,7 +87,7 @@ This gave the following configuration ::
 I then did ::
 
          make
-         make install    
+         make install
 
 Post Install Steps
 ------------------
@@ -101,7 +101,7 @@ Testing
 -------
 This module has not been yet been properly tested and so should be considered experimental.
 
-So far, a users 4 core job was run to completion. Tests are required.
+Several user's jobs up to 8 cores have been submitted and ran to completion.
 
 Module File
 -----------
@@ -124,11 +124,11 @@ Module File Location: :code:`/usr/local/modulefiles/apps/code_saturne/4.0.0`
 		puts stderr "   Adds `code_saturn-$codesaturneversion' to your PATH environment variable and necessary libraries"
 	}
 
-	set     codesaturneversion 4.0.0
+	set     codesaturneversion 4.0.
+  module load mpi/gcc/openmpi/1.8.3
 
 	module-whatis   "loads the necessary `code_saturne-$codesaturneversion' library paths"
 
 	set cspath /usr/local/packages6/apps/gcc/4.4.7/code_saturne/4.0
 	prepend-path MANPATH $cspath/share/man
 	prepend-path PATH $cspath/bin
-


### PR DESCRIPTION
A user was having issues with running Code Saturne from /fastdata. This is because /fastdata does not support the necessary posix locks. Current documented workaround is to use /data instead.

The same user reported intermittent job failures. I eventually determined that the job only ever failed if two or more MPI processes were assigned to the same node. If an N process job ran on N distinct nodes, it succeeded. This is because Code Saturne was adding a the flag --npernode command to the mpiexec command on submission from the GUI. E.g.

    mpiexec -n 5 --npernode 1

My current workaround for this is to modify the ``mpiexec_n_per_node`` entry in code_saturne.cfg to be empty (see commit) changesL This implicitly allows multiple processes to be assigned to the same node.

I tried setting --npernode to something like 12 but this resulted in 'insufficient slots available' errors.

This will need investigating further if we are to ensure efficient allocation of resources but it has solved the current problems.