### PR TITLE
Git 2.5

### DIFF
--- a/software/compilers/git.rst
+++ b/software/compilers/git.rst
@@ -24,5 +24,5 @@ Installation notes
 ------------------
 Version 2.5 of git was installed using gcc 5.2 using the following install script and module file:
 
-  * `install_git_2.5.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/compilers/git/install_git_5.2.sh>`_
-  * `git 2.5 modulefile <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/compilers/git/2.5>`_ located on the system at ``/usr/local/modulefiles/compilers/git/2.5``
+* `install_git_2.5.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/compilers/git/install_git_5.2.sh>`_
+* `git 2.5 modulefile <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/compilers/git/2.5>`_ located on the system at ``/usr/local/modulefiles/compilers/git/2.5``

--- a/software/compilers/git.rst
+++ b/software/compilers/git.rst
@@ -1,0 +1,28 @@
+git
+===
+
+.. sidebar:: git
+
+   :Latest version: 2.5
+   :Dependancies: gcc 5.2
+   :URL: https://git-scm.com/
+
+Git is a free and open source distributed version control system designed to handle everything from small to very large projects with speed and efficiency.
+
+Usage
+-----
+An old version of git is installed as part of the system's opertaing system. As such, it is available everywhere, including on the log-in nodes  ::
+
+    $ git --version
+    git version 1.7.1
+
+This was released in April 2010. We recommend that you load the most up to date version using modules - something that can only be done after starting an interactive ``qrsh`` or ``qsh`` session ::
+
+    module load apps/gcc/5.2/git/2.5
+
+Installation notes
+------------------
+Version 2.5 of git was installed using gcc 5.2 using the following install script and module file:
+
+  * `install_git_2.5.sh <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/compilers/git/install_git_5.2.sh>`_
+  * `git 2.5 modulefile <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/compilers/git/2.5>`_ located on the system at ``/usr/local/modulefiles/compilers/git/2.5``

--- a/software/install_scripts/apps/git/install_git_2.5.sh
+++ b/software/install_scripts/apps/git/install_git_2.5.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+module load compilers/gcc/5.2 
+
+version=2.5.0
+install_dir=/usr/local/packages6/apps/gcc/5.2/git/$version
+mkdir -p $install_dir
+
+tar -xzf git-${version}.tar.gz
+cd git-${version}
+make configure
+./configure --prefix=$install_dir
+make all
+make install

--- a/software/modulefiles/apps/git/2.5
+++ b/software/modulefiles/apps/git/2.5
@@ -1,0 +1,21 @@
+#%Module1.0#####################################################################
+##
+## JAGS 3.4 module file
+##
+
+## Module file logging
+source /usr/local/etc/module_logging.tcl
+##
+
+
+
+proc ModulesHelp { } {
+        puts stderr "Makes git 2.5.0 available"
+}
+
+set version 2.5.0
+set GIT_DIR /usr/local/packages6/apps/gcc/5.2/git/$version
+
+module-whatis   "Makes git 2.5.0 available"
+
+prepend-path PATH $GIT_DIR/bin


### PR DESCRIPTION
Required for http://bcbio-nextgen.readthedocs.org/en/latest/, an app requested by a SITRAN research group.

Also required for general use since the current version of git on the system is over 5 years out of date!