### PR TITLE
Glossary

### DIFF
--- a/glossary.rst
+++ b/glossary.rst
@@ -2,14 +2,31 @@
 
 Glossary of Terms
 =================
-The worlds of scientific and high performance computing are full of technical jargon that can seem daunting to newcomers. This glossary attempts to explain some of the most common terms as quickly as possible.
+The worlds of scientific and high performance computing are full of technical
+jargon that can seem daunting to newcomers. This glossary attempts to explain
+some of the most common terms as quickly as possible.
 
-* **HPC** - 'High Performance Computing'. The exact definition of this term is sometimes a subject of great debate but for the purposes of our services you can think of it as 'Anything that requires more resources than a typical high-spec desktop or laptop PC'.
+.. glossary::
 
-* **GPU** - Acronymn for Graphics Processing Unit.
+    HPC
+        'High Performance Computing'. The exact definition of this term is
+        sometimes a subject of great debate but for the purposes of our
+        services you can think of it as 'Anything that requires more resources
+        than a typical high-spec desktop or laptop PC'.
 
-* **SGE** - Acronymn for Sun Grid Engine.
+    GPU
+        Acronymn for Graphics Processing Unit.
 
-* **Sun Grid Engine** - The Sun Grid Engine is the software that controls and allocates resources on the system. There are many variants of 'Sun Grid Engine' in use worldwide and the variant in use at Sheffield is the `Son of Grid Engine <https://arc.liv.ac.uk/trac/SGE>`_
+    SGE 
+        Acronymn for Sun Grid Engine.
 
-* **Wallclock time** - The actual time taken to complete a job as measured by a clock on the wall or your wristwatch. 
+    Sun Grid Engine
+        The Sun Grid Engine is the software that controls and allocates
+        resources on the system. There are many variants of 'Sun Grid Engine'
+        in use worldwide and the variant in use at Sheffield is the 
+        `Son of Grid Engine <https://arc.liv.ac.uk/trac/SGE>`_
+
+    Wallclock time
+        The actual time taken to complete a job as measured by a clock on the
+        wall or your wristwatch. 
+

--- a/index.rst
+++ b/index.rst
@@ -9,7 +9,7 @@ Iceberg
    :alt: A picture showing some of the Iceberg hardware.
 
 Welcome to the **Iceberg** user manual. Iceberg is the University of Sheffield's
-central High Perfomance Computing (HPC) resource. Its mission is to meet
+central High Perfomance Computing (:term:`HPC`) resource. Its mission is to meet
 the intensive computing requirements of research projects at Sheffield University.
 
 This manual aims to provide you all the information you need to use iceberg.

--- a/software/libs/hdf5.rst
+++ b/software/libs/hdf5.rst
@@ -64,6 +64,11 @@ Installation notes
 ------------------
 This section is primarily for administrators of the system.
 
+**Version 1.8.16 built using GCC Compiler, with seperate ZLIB and SZIP**
+
+* `install_hdf5.sh   <https://github.com/rcgsheffield/iceberg_software/blob/master/software/install_scripts/libs/gcc/4.4.7/hdf5/install_hdf5.sh>`_ Install script
+* `1.8.16   <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/libs/gcc/hdf5/1.8.16>`_
+
 **Version 1.8.15-patch1 built using PGI Compiler**
 
 Here are the build details for the module `libs/hdf5/pgi/1.8.15-patch1`
@@ -71,7 +76,7 @@ Here are the build details for the module `libs/hdf5/pgi/1.8.15-patch1`
 Compiled using PGI 15.7 and OpenMPI 1.8.8
 
 * `install_pgi_hdf5_1.8.15-patch1.sh   <https://github.com/rcgsheffield/blob/master/software/install_scripts/libs/pgi/hdf5/install_pgi_hdf5_1.8.15-patch1.sh>`_ Install script
-* `Modulefile <https://github.com/cgsheffield/iceberg_software/blob/master/software/modulefiles/libs/pgi/hdf5/1.8.15-patch1>`_ located on the system at ``/usr/local/modulefiles/libs/hdf5/pgi/1.8.15-patch1``
+* `Modulefile <https://github.com/rcgsheffield/iceberg_software/blob/master/software/modulefiles/libs/pgi/hdf5/1.8.15-patch1>`_ located on the system at ``/usr/local/modulefiles/libs/hdf5/pgi/1.8.15-patch1``
 
 **gcc versions**
 


### PR DESCRIPTION
This converts the glossary to use the sphix glossary environment: http://sphinx-doc.org/markup/para.html?highlight=glossary#directive-glossary

You can then link to terms defined in the glossary by doing 
```
:term:`HPC`
```