### PR TITLE
Scheduler command reference

### DIFF
--- a/software/index.rst
+++ b/software/index.rst
@@ -16,6 +16,7 @@ the research computing team at `research-it@sheffield.ac.uk <research-it@sheffie
     apps/index
     libs/index
     compilers/index
+    scheduler/index
     mpi/index
 
 There are many versions of applications, libraries and compilers installed on the iceberg cluster. In order to avoid conflict between these software items we employ a system called modules. Having logged onto a worker nodes, users are advised to select the software (and the version of the software) they intend to use by utilising the module command.
@@ -24,5 +25,6 @@ There are many versions of applications, libraries and compilers installed on th
 * :ref:`applications`
 * :ref:`development-tools` (including compilers)
 * :ref:`Libraries`
+* :ref:`scheduler` Commands for interacting with the scheduler
 * :ref:`mpi` Parallel Programming
 

--- a/software/scheduler/index.rst
+++ b/software/scheduler/index.rst
@@ -1,0 +1,13 @@
+.. _scheduler:
+
+Scheduler
+=========
+
+This is a reference section for commands that allow you to interact with the scheduler.
+
+.. toctree::
+    :maxdepth: 1
+    :glob:
+    
+    ./*
+

--- a/software/scheduler/qrsh.rst
+++ b/software/scheduler/qrsh.rst
@@ -1,0 +1,13 @@
+qrsh
+====
+`qrsh` is a scheduler command that requests an interactive session on a worker node. The resulting session will **not** support graphical applications. You will usually run this command from the head node.
+
+Examples
+--------
+Request an interactive session that provides the default amount of memory resources ::
+
+    qrsh
+
+Request an interactive session that provides 10 Gigabytes of real and virtual memory ::
+
+    qrsh -l rmem=10G -l mem=10G

--- a/software/scheduler/qrshx.rst
+++ b/software/scheduler/qrshx.rst
@@ -9,7 +9,7 @@ Request an interactive session that provides the default amount of memory resour
     qrshx
     gedit
 
-Request an interactive session that provides 10 Gigagbytes of memory and launch the latest version of MATLAB ::
+Request an interactive session that provides 10 Gigabytes of memory and launch the latest version of MATLAB ::
 
     qrshx -l mem=10G -l rmem=10G
     module load apps/matlab

--- a/software/scheduler/qrshx.rst
+++ b/software/scheduler/qrshx.rst
@@ -1,19 +1,25 @@
+.. _qrshx:
+
 qrshx
 =====
 `qrshx` is a scheduler command that requests an interactive session on a worker node. The resulting session will support graphical applications. You will usually run this command from the head node.
 
 Examples
 --------
-Request an interactive session that provides the default amount of memory resources and launch the `gedit` text editor ::
+Request an interactive X-Windows session that provides the default amount of memory resources and launch the `gedit` text editor ::
 
     qrshx
     gedit
 
-Request an interactive session that provides 10 Gigabytes of memory and launch the latest version of MATLAB ::
+Request an interactive X-Windows session that provides 10 Gigabytes of real and virtual memory and launch the latest version of MATLAB ::
 
     qrshx -l mem=10G -l rmem=10G
     module load apps/matlab
     matlab
+
+Request an interactive X-Windows session that provides 10 Gigabytes of real and virtual memory and 4 CPU cores ::
+
+    qrshx -l rmem=10G -l mem=10G -pe openmp 4
 
 Sysadmin notes
 --------------

--- a/software/scheduler/qrshx.rst
+++ b/software/scheduler/qrshx.rst
@@ -1,0 +1,23 @@
+qrshx
+=====
+`qrshx` is a scheduler command that requests an interactive session on a worker node. The resulting session will support graphical applications. You will usually run this command from the head node.
+
+Examples
+--------
+Request an interactive session that provides the default amount of memory resources and launch the `gedit` text editor ::
+
+    qrshx
+    gedit
+
+Request an interactive session that provides 10 Gigagbytes of memory and launch the latest version of MATLAB ::
+
+    qrshx -l mem=10G -l rmem=10G
+    module load apps/matlab
+    matlab
+
+Sysadmin notes
+--------------
+qrshx is a Sheffield-developed modification to the standard set of scheduler commands. It is at `/usr/local/bin/qrshx` and contains the following ::
+
+    #!/bin/sh
+    qrsh -v DISPLAY -pty y $* bash

--- a/software/scheduler/qsh.rst
+++ b/software/scheduler/qsh.rst
@@ -1,0 +1,17 @@
+qsh
+===
+`qsh` is a scheduler command that requests an interactive X-windows session on a worker node. The resulting terminal is not user-friendly and we recommend that you use our :ref:`qrshx` command instead.
+
+Examples
+--------
+Request an interactive X-Windows session that provides the default amount of memory resources ::
+
+    qsh
+
+Request an interactive X-Windows session that provides 10 Gigabytes of real and virtual memory ::
+
+    qsh -l rmem=10G -l mem=10G
+
+Request an interactive X-Windows session that provides 10 Gigabytes of real and virtual memory and 4 CPU cores ::
+
+   qsh -l rmem=10G -l mem=10G -pe openmp 4

--- a/software/scheduler/qstat.rst
+++ b/software/scheduler/qstat.rst
@@ -1,0 +1,21 @@
+qstat
+=====
+`qstat` is a scheduler command that displays the status of the queues.
+
+Examples
+--------
+Display all jobs queued on the system ::
+
+    qstat
+
+Display all jobs queued by the username foo1bar ::
+
+    qstat -u foo1bar
+
+Display all jobs in the openmp parallel environment ::
+
+    stat -pe openmp
+
+Display all jobs in the queue named foobar ::
+
+    qstat -q foobar.q

--- a/software/scheduler/qsub.rst
+++ b/software/scheduler/qsub.rst
@@ -1,0 +1,9 @@
+qsub
+====
+`qsub` is a scheduler command that submits a batch job to the system.
+
+Examples
+--------
+Submit a batch job called myjob.sh to the system ::
+
+    qsub myjob.sh


### PR DESCRIPTION
The creation of this section was prompted by the development of our qrshx command which creates an X windows session that isn't disgusting (unlike qsh). We had nowhere to put these modifications and seem to have a few undocumented ones (Qsh for example which has been on Iceberg for ages but isn't documented anywhere)

I also wanted to start collecting a user-friendly reference section for scheduler commands that contained the most used options.