### PR TITLE
update GPU docs to remove need to request a project

### DIFF
--- a/gpu/GPUAccess.rst
+++ b/gpu/GPUAccess.rst
@@ -1,7 +1,0 @@
-.. _GPUAccess:
-
-Requesting access to GPU facilities
------------------------------------
-In order to ensure that the nodes hosting the GPUs run only GPU related tasks, we have defined a special project-group for accessing these nodes. If you wish to take advantage of the GPU processors, please contact research-it@sheffield.ac.uk asking to join the GPU project group.
-
-Any iceberg user can apply to join this group. However, because our GPU resources are limited we will need to discuss the needs of the user and obtain consent from the project leader before allowing usage.

--- a/gpu/PGI_compiler.rst
+++ b/gpu/PGI_compiler.rst
@@ -2,7 +2,7 @@
 
 Compiling on the GPU using the PGI Compiler
 ===========================================
-The PGI Compilers are a set of commercial Fortran,C and C++ compilers from the Portland Group. To make use of them, first start an :ref:`interactive GPU session <GPUInteractive>` and run one of the following module commands, depending on which version of the compilers you wish to use ::
+The PGI Compilers are a set of commercial Fortran,C and C++ compilers from the Portland Group. To make use of them, first start an :ref:`interactive GPU session <GPUJobs>` and run one of the following module commands, depending on which version of the compilers you wish to use ::
 
         module load compilers/pgi/13.1
         module load compilers/pgi/14.4

--- a/gpu/gpu_jobs.rst
+++ b/gpu/gpu_jobs.rst
@@ -1,14 +1,17 @@
-.. _GPUInteractive:
+.. _GPUJobs:
 
 .. toctree::
     :maxdepth: 1
     :glob:
 
-Interactive use of the GPUs
-===========================
-Once you are included in the GPU project group you may start using the GPU enabled nodes interactively by typing ::
+Submitting GPU jobs
+===================
 
-        qsh -l gpu=1 -P gpu
+Interactive use of the GPUs
+---------------------------
+You can access GPU enabled nodes interactively by typing ::
+
+        qsh -l gpu=1 
 
 the ``gpu=`` parameter determines how many GPUs you are requesting. Currently, the maximum number of GPUs allowed per job is set to 4, i.e. you cannot exceed ``gpu=4``. Most jobs will only make use of one GPU.
 
@@ -23,3 +26,15 @@ Interactive sessions provide you with 2 Gigabytes of CPU RAM by default which is
         -l gpu_arch=nvidia-k40m -l mem=13G
 
 The above will give you 1Gb more CPU RAM than GPU RAM for each of the respective GPU architectures. 
+
+Submitting batch GPU jobs
+-------------------------
+
+To run batch jobs on gpu nodes, edit your jobfile to include a request for gpus, e.g. for a single GPU ::
+
+	#$ -l gpu=1
+
+You can also use the the ``gpu_arch`` discussed aboved to target a specific gpu model ::
+
+	#$ -l gpu_arch=nvidia-m2070
+

--- a/gpu/index.rst
+++ b/gpu/index.rst
@@ -16,8 +16,7 @@ The `GPUComputing@Sheffield website
 
     GPUCommunity
     GPUHardware
-    GPUAccess
-    gpu_interactive
+    gpu_jobs
     nvidia_compiler
     PGI_compiler
     gpu_software

--- a/gpu/nvidia_compiler.rst
+++ b/gpu/nvidia_compiler.rst
@@ -1,6 +1,6 @@
 Compiling on the GPU using the NVIDIA Compiler
 ==============================================
-To compile GPU code using the NVIDA compiler, nvcc, first start an :ref:`interactive GPU session <GPUInteractive>`. Next, you need to set up the compiler environment via one of the following module statements ::
+To compile GPU code using the NVIDA compiler, nvcc, first start an :ref:`interactive GPU session <GPUjobs>`. Next, you need to set up the compiler environment via one of the following module statements ::
 
         module load libs/cuda/3.2.16
         module load libs/cuda/4.0.17


### PR DESCRIPTION
I've made a change to the scheduler so anyone can request GPUs.  Although the gpu project still exists in the scheduler config (to keep non-gpu from spilling onto the nodes) all users are automatically members of the project.  Also, the scheduler will automatically add the project request if you request GPUs to using "-P gpu" is no longer necessary.

I also rejigged things a bit to include batch info, rather than just interactive usage, to make it clear that batch usage is thing.